### PR TITLE
APPSREPO-338 : Bring the existing bencharmark-device-sync driver up-to-date

### DIFF
--- a/src/main/java/org/springframework/social/alfresco/api/entities/Person.java
+++ b/src/main/java/org/springframework/social/alfresco/api/entities/Person.java
@@ -18,6 +18,8 @@ package org.springframework.social.alfresco.api.entities;
 
 import java.util.Date;
 
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
 
 /**
  * A person entity describes the user as they are known to Alfresco.
@@ -25,6 +27,7 @@ import java.util.Date;
  * @author jottley
  * 
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class Person
 {
     private boolean enabled;


### PR DESCRIPTION
   - added @JsonIgnoreProperties(ignoreUnknown=true) to People in order to allow allow running of dataload(create site members step)
     Exception throwed when running dataload against 5.2.4-SNAPSHOT: 'Unrecognized field "aspectNames" (Class org.springframework.social.alfresco.api.entities.Person)'